### PR TITLE
[Feature Enhancement]: Textract Output Config

### DIFF
--- a/code/comprehend_sync/comprehend_processor.py
+++ b/code/comprehend_sync/comprehend_processor.py
@@ -135,7 +135,9 @@ def runComprehend(bucketName, objectName, callerId):
         lenOfEncodedText = len(text)
         print("Comprehend documentId {} processing page {}".format(documentId, str(page_num)))
         print("Length of encoded text is " + str(lenOfEncodedText))
-        if lenOfEncodedText > COMPREHEND_CHARACTER_LIMIT:
+        if lenOfEncodedText == 0:
+            pass
+        elif lenOfEncodedText > COMPREHEND_CHARACTER_LIMIT:
             print("Size was too big to run singularly; breaking up the page text into chunks")
             try:
                 chunksOfText = chunkUpTheText(text)

--- a/code/lambda_layer/pipeline/python/trp.py
+++ b/code/lambda_layer/pipeline/python/trp.py
@@ -284,7 +284,7 @@ class Field:
                 for eid in item['Ids']:
                     vkvs = blockMap[eid]
                     if 'VALUE' in vkvs['EntityTypes']:
-                        if('Relationships' in vkvs):
+                        if('Relationships' in vkvs and vkvs['Relationships'] is not None):
                             for vitem in vkvs['Relationships']:
                                 if(vitem["Type"] == "CHILD"):
                                     self._value = FieldValue(vkvs, vitem['Ids'], blockMap)

--- a/infrastructure/lib/textract-pipeline-stack.ts
+++ b/infrastructure/lib/textract-pipeline-stack.ts
@@ -205,7 +205,8 @@ export class TextractPipelineStack extends cdk.Stack {
       environment: {
         TEXTRACT_SNS_TOPIC_ARN : textractJobCompletionTopic.topicArn,
         TEXTRACT_SNS_ROLE_ARN : textractServiceRole.roleArn,
-        METADATA_SNS_TOPIC_ARN : props.metadataTopic.topicArn
+        METADATA_SNS_TOPIC_ARN : props.metadataTopic.topicArn,
+        TEXTRACT_RESULTS_BUCKET: textractResultsBucket.bucketName
       }
     });
 
@@ -215,10 +216,9 @@ export class TextractPipelineStack extends cdk.Stack {
     textractAsyncStarter.addEventSource(new S3EventSource(asyncdocBucket, {
       events: [ s3.EventType.OBJECT_CREATED ]
     }));
-    //Run when a job is successfully complete
-    textractAsyncStarter.addEventSource(new SnsEventSource(textractJobCompletionTopic))
     //Permissions
     asyncdocBucket.grantRead(textractAsyncStarter)
+    textractResultsBucket.grantReadWrite(textractAsyncStarter)
     textractAsyncStarter.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ["iam:PassRole"],


### PR DESCRIPTION
Improving the Textract portion of the NLP pipeline to utilize Output Config, thereby reducing calls to GetDocumentAnalysis Textract API, and increasing ability to process larger, longer documents within Lambda timeout specifications.

Major Changes:
1. AsyncStarter now has writes to read and write to Textract results bucket
2. AsyncProcessor no longer calls Textract APIs directly, but rather reads from a pre-destined location to where Textract service will write its output.
3. Comprehend Sync bug improvement on allowing no text to be interpreted as part of DetectPhrases portion of code.
